### PR TITLE
[jira-support] Add support for JIRA ticket numbers

### DIFF
--- a/git-templates/hooks/prepare-commit-msg
+++ b/git-templates/hooks/prepare-commit-msg
@@ -17,6 +17,12 @@ BRANCH_NAME="${BRANCH_NAME##*/}"
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 BRANCH_IN_COMMIT=$(grep -c "\[$BRANCH_NAME\]" $1)
 
+TICKET_NUMBER=$(echo "$BRANCH_NAME" | grep -Eo '^[A-Z0-9]{1,10}-[0-9]+')
+
 if [ -n "$BRANCH_NAME" ] && [[ $REMOTE_PUSH_URL = *dreipol* ]] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
-  sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
+  if [ -n "$TICKET_NUMBER" ]; then
+    sed -i.bak -e "1s/^/[$TICKET_NUMBER] /" $1
+  else
+    sed -i.bak -e "1s/^/[$BRANCH_NAME] /" $1
+  fi
 fi


### PR DESCRIPTION
This little helper checks if the branch name is prefixed with a JIRA ticket number. So if I use "My commit" as message on my branch "ABC-123-my-cool-feature" the message will look like this: "[ABC-123] My commit".